### PR TITLE
Fix retrieval of Wyscout substitutions

### DIFF
--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -92,7 +92,7 @@ def jsonfiles_to_h5(jsonfiles, h5file, append=True):
 
 def extract_data(jsonfile):
     with open(jsonfile) as fh:
-        root = json.load(fh)
+        root = json.load(fh, encoding='utf-8')
 
     return {
         "game": extract_game(root),

--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -23,7 +23,7 @@ def jsonfiles_to_h5(datafolder, h5file):
 
 def add_competitions(competitions_url, h5file):
     with open(competitions_url, "rt", encoding="utf-8") as fh:
-        competitions = json.load(fh)
+        competitions = json.load(fh, encoding='utf-8')
     pd.DataFrame(competitions).to_hdf(h5file, "competitions")
 
 
@@ -31,7 +31,7 @@ def add_matches(matches_url, h5file):
     matches = []
     for competition_file in get_jsonfiles(matches_url):
         with open(competition_file, "rt", encoding="utf-8") as fh:
-            matches += json.load(fh)
+            matches += json.load(fh, encoding='utf-8')
     pd.DataFrame([flatten(m) for m in matches]).to_hdf(h5file, "matches")
 
 
@@ -42,7 +42,7 @@ def add_players_and_teams(lineups_url, h5file):
         get_jsonfiles(lineups_url), desc=f"...Adding players and teams to {h5file}"
     ):
         with open(lineup_file, "r") as fh:
-            lineups += json.load(fh)
+            lineups += json.load(fh, encoding='utf-8')
             for lineup in lineups:
                 for p in [flatten_id(p) for p in lineup["lineup"]]:
                     players[p["player_id"]] = p
@@ -62,7 +62,7 @@ def add_events(events_url, h5file):
             get_jsonfiles(events_url), desc=f"converting events files to {h5file}"
         ):
             with open(events_file, "r") as fh:
-                events = json.load(fh)
+                events = json.load(fh, encoding='utf-8')
             eventsdf = pd.DataFrame([flatten_id(e) for e in events])
             match_id = get_match_id(events_file)
             eventsdf["match_id"] = match_id

--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -23,7 +23,7 @@ def jsonfiles_to_h5(datafolder, h5file):
 
 def add_competitions(competitions_url, h5file):
     with open(competitions_url, "rt", encoding="utf-8") as fh:
-        competitions = json.load(fh, encoding='utf-8')
+        competitions = json.load(fh)
     pd.DataFrame(competitions).to_hdf(h5file, "competitions")
 
 
@@ -31,7 +31,7 @@ def add_matches(matches_url, h5file):
     matches = []
     for competition_file in get_jsonfiles(matches_url):
         with open(competition_file, "rt", encoding="utf-8") as fh:
-            matches += json.load(fh, encoding='utf-8')
+            matches += json.load(fh)
     pd.DataFrame([flatten(m) for m in matches]).to_hdf(h5file, "matches")
 
 
@@ -41,8 +41,8 @@ def add_players_and_teams(lineups_url, h5file):
     for lineup_file in tqdm.tqdm(
         get_jsonfiles(lineups_url), desc=f"...Adding players and teams to {h5file}"
     ):
-        with open(lineup_file, "r") as fh:
-            lineups += json.load(fh, encoding='utf-8')
+        with open(lineup_file, "r", encoding='utf-8') as fh:
+            lineups += json.load(fh)
             for lineup in lineups:
                 for p in [flatten_id(p) for p in lineup["lineup"]]:
                     players[p["player_id"]] = p
@@ -61,8 +61,8 @@ def add_events(events_url, h5file):
         for events_file in tqdm.tqdm(
             get_jsonfiles(events_url), desc=f"converting events files to {h5file}"
         ):
-            with open(events_file, "r") as fh:
-                events = json.load(fh, encoding='utf-8')
+            with open(events_file, "r", encoding='utf-8') as fh:
+                events = json.load(fh)
             eventsdf = pd.DataFrame([flatten_id(e) for e in events])
             match_id = get_match_id(events_file)
             eventsdf["match_id"] = match_id

--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -189,7 +189,7 @@ def get_player_games(match, events):
             for player in formation.get("lineup", [])
         }
 
-        substitutions = formation.get("substitutions") or []
+        substitutions = formation.get("substitutions", [])
         for substitution in substitutions:
             substitute = {
                 "game_id": game_id,

--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -228,7 +228,7 @@ def augment_events(events_df):
         else events_df.subEventName
     )
     events_df["period_id"] = events_df.matchPeriod.apply(
-        lambda x: int(x.replace("H", ""))
+        lambda x: wyscout_periods[x]
     )
     events_df["player_id"] = events_df["playerId"]
     events_df["team_id"] = events_df["teamId"]
@@ -247,6 +247,14 @@ def get_tagsdf(events):
     for (tag_id, column) in wyscout_tags:
         tagsdf[column] = tags.apply(lambda x: tag_id in x)
     return tagsdf
+
+wyscout_periods = {
+    '1H':1,
+    '2H':2,
+    'E1':3,
+    'E2':4,
+    'P':5
+}
 
 
 wyscout_tags = [

--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -18,7 +18,7 @@ def jsonfiles_to_h5(jsonfiles, h5file):
     with pd.HDFStore(h5file) as store:
         for jsonfile in jsonfiles:
             with open(jsonfile, "r") as fh:
-                root = json.load(fh)
+                root = json.load(fh, encoding='utf-8')
             matches.append(get_match(root))
             teams += get_teams(root)
             players += get_players(root)

--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -190,15 +190,17 @@ def get_player_games(match, events):
         }
 
         substitutions = formation.get("substitutions", [])
-        for substitution in substitutions:
-            substitute = {
-                "game_id": game_id,
-                "team_id": team_id,
-                "player_id": substitution["playerIn"],
-                "minutes_played": duration - substitution["minute"],
-            }
-            pg[substitution["playerIn"]] = substitute
-            pg[substitution["playerOut"]]["minutes_played"] = substitution["minute"]
+        
+        if substitutions != 'null':
+            for substitution in substitutions:
+                substitute = {
+                    "game_id": game_id,
+                    "team_id": team_id,
+                    "player_id": substitution["playerIn"],
+                    "minutes_played": duration - substitution["minute"],
+                }
+                pg[substitution["playerIn"]] = substitute
+                pg[substitution["playerOut"]]["minutes_played"] = substitution["minute"]
         playergames = {**playergames, **pg}
     return pd.DataFrame(playergames.values())
 


### PR DESCRIPTION
I was playing with the new dump of Wyscout data and when converting it into SPADL it fails dealing with substitutes. This is because the existing logic sets the `substitutions` variable to `True` or `False` because the assignment of the empty list is outside of the `.get("substitutions")` method call.

I also ran into a json.load problem which seems to be related to not using utf-8 encoding (issue #11 seems to be the same issue) so I've pushed a commit to fix that too.