### PR TITLE
[xT] Incorporates movement success probability

### DIFF
--- a/socceraction/xthreat.py
+++ b/socceraction/xthreat.py
@@ -85,20 +85,20 @@ def move_transition_matrix(actions, l=N, w=M):
     """ Compute the move transition matrix from the given actions.
 
     This is, when a player chooses to move, the probability that he will
-    end up in each of the other cells of the grid.
+    end up in each of the other cells of the grid successfully.
 
     :param actions: Actions, in SPADL format.
     :param l: Amount of grid cells in the x-dimension of the grid.
     :param w: Amount of grid cells in the y-dimension of the grid.
     :return: The transition matrix.
     """
-    move_actions = actions[(((actions.type_name == "pass") | (actions.type_name == "dribble")
-                             | (actions.type_name == "cross"))
-                            & (actions.result_name == "success"))]
+    move_actions = actions[((actions.type_name == "pass") | (actions.type_name == "dribble")
+                             | (actions.type_name == "cross"))]
 
     X = pd.DataFrame()
     X["start_cell"] = _get_flat_indexes(move_actions.start_x, move_actions.start_y, l, w)
     X["end_cell"] = _get_flat_indexes(move_actions.end_x, move_actions.end_y, l, w)
+    X["result_name"] = move_actions.result_name
 
     vc = X.start_cell.value_counts(sort=False)
     start_counts = np.zeros(w * l)
@@ -107,7 +107,7 @@ def move_transition_matrix(actions, l=N, w=M):
     transition_matrix = np.zeros((w * l, w * l))
 
     for i in range(0, w * l):
-        vc2 = X[(X.start_cell == i)].end_cell.value_counts(sort=False)
+        vc2 = X[((X.start_cell == i) & (X.result_name == "success"))].end_cell.value_counts(sort=False)
         transition_matrix[i, vc2.index] = vc2 / start_counts[i]
 
     return transition_matrix
@@ -116,7 +116,7 @@ def move_transition_matrix(actions, l=N, w=M):
 class ExpectedThreat:
     """An implementation of Karun Singh's Expected Threat model (https://karun.in/blog/expected-threat.html)."""
 
-    def __init__(self, l=N, w=M, eps=0.01):
+    def __init__(self, l=N, w=M, eps=1e-5):
         self.l = l
         self.w = w
         self.eps = eps
@@ -256,5 +256,3 @@ class ExpectedThreat:
 
         except ImportError:
             warnings.warn("Could not import the following package: plotly.")
-
-


### PR DESCRIPTION
Modifies the xT implementation to incorporate the probability of moving from (x,y) --> (z,w) successfully. This probability term is directly absorbed into the transition matrix.

The `s` term for the 'Move' branch described in the [slide](https://docs.google.com/presentation/d/1tu603CdONhI17AZTrd3mdf1UAf7k-rHwwCLSU_tCx6g/edit#slide=id.g6220bb1d1d_0_287) below is what's being added:
![image](https://user-images.githubusercontent.com/5836923/72268852-9abf6080-3648-11ea-9e22-6b95be108e07.png)

`T(x,y,z,w) = p(x,y,z,w) * s(x,y,z,w) = (count(x,y,z,w) / count(x,y,_,_)) * (count_successful(x,y,z,w) / count(x,y,z,w)) = count_successful(x,y,z,w) / count(x,y,_,_)`

xT map (`eps = 1e-5`) before change:
![image](https://user-images.githubusercontent.com/5836923/72268676-3f8d6e00-3648-11ea-8773-f69a50f56be0.png)

xT map (`eps = 1e-5`) after change:
![image](https://user-images.githubusercontent.com/5836923/72268690-4916d600-3648-11ea-9046-f8aed4993478.png)
