### PR TITLE
adjusting goalscore function to not match goalkick when looking for goals fix #44

### DIFF
--- a/socceraction/atomic/vaep/features.py
+++ b/socceraction/atomic/vaep/features.py
@@ -242,7 +242,7 @@ def goalscore(gamestates: GameStates) -> Features:
     """
     actions = gamestates[0]
     teamA = actions['team_id'].values[0]
-    goals = actions['type_name'].str.contains('goal')
+    goals = actions.type_name == 'goal'
     owngoals = actions['type_name'].str.contains('owngoal')
 
     teamisA = actions['team_id'] == teamA


### PR DESCRIPTION
When following the tutorials and creating the feature matrix in the tutorials, the goalscore function was also counting goalkick actions.