### PR TITLE
fix atomic label function goal_from_shot

### DIFF
--- a/socceraction/atomic/vaep/labels.py
+++ b/socceraction/atomic/vaep/labels.py
@@ -101,8 +101,8 @@ def goal_from_shot(actions: DataFrame[AtomicSPADLSchema]) -> pd.DataFrame:
         A dataframe with a column 'goal' and a row for each action set to
         True if a goal was scored from the current action; otherwise False.
     """
-    goals = (actions['type_id'] == atomicspadl.actiontypes.index('shot')) & (
-        actions['type_id'] == atomicspadl.actiontypes.index('goal')
+    goals = (actions["type_id"] == atomicspadl.actiontypes.index("shot")) & (
+        actions["type_id"].shift(-1) == atomicspadl.actiontypes.index("goal")
     )
 
-    return pd.DataFrame(goals, columns=['goal'])
+    return pd.DataFrame(goals.rename("goal"))

--- a/tests/atomic/test_atomic_vaep.py
+++ b/tests/atomic/test_atomic_vaep.py
@@ -11,14 +11,14 @@ from socceraction.atomic.vaep import features as fs
 @pytest.fixture
 def test_goal_df() -> pd.DataFrame:
     return pd.DataFrame(
-        [spadlconfig.actiontypes.index("shot"), spadlconfig.actiontypes.index("goal")],
-        columns=["type_id"],
+        [spadlconfig.actiontypes.index('shot'), spadlconfig.actiontypes.index('goal')],
+        columns=['type_id'],
     )
 
 
 def test_atomic_goal_from_shot_label(test_goal_df: pd.DataFrame) -> None:
-    assert (lab.goal_from_shot(test_goal_df) == pd.DataFrame([[True], [False]], columns=["goal"]))[
-        "goal"
+    assert (lab.goal_from_shot(test_goal_df) == pd.DataFrame([[True], [False]], columns=['goal']))[
+        'goal'
     ].all()
 
 

--- a/tests/atomic/test_atomic_vaep.py
+++ b/tests/atomic/test_atomic_vaep.py
@@ -2,8 +2,24 @@ import pandas as pd
 import pytest
 
 import socceraction.atomic.spadl as atomicspadl
+import socceraction.atomic.spadl.config as spadlconfig
+import socceraction.atomic.vaep.labels as lab
 from socceraction.atomic.vaep import AtomicVAEP
 from socceraction.atomic.vaep import features as fs
+
+
+@pytest.fixture
+def test_goal_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        [spadlconfig.actiontypes.index("shot"), spadlconfig.actiontypes.index("goal")],
+        columns=["type_id"],
+    )
+
+
+def test_atomic_goal_from_shot_label(test_goal_df: pd.DataFrame) -> None:
+    assert (lab.goal_from_shot(test_goal_df) == pd.DataFrame([[True], [False]], columns=["goal"]))[
+        "goal"
+    ].all()
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
The label function "goal_from_shot" seemed to not have been correctly changed from socceraction.vaep.labels to socceraction.atomic.vaep.labels and misses all goals as there are no actions that have both a "shot" and "goal" actiontype.

This PR fixes this issue and adds a test to check correctness of the function,