### PR TITLE
Discard fairplay actions and interrupted events

### DIFF
--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -108,7 +108,10 @@ def _get_result_id(args: Tuple[str, bool, Dict[int, Any]]) -> int:
 
 def _get_type_id(args: Tuple[str, bool, Dict[int, Any]]) -> int:  # noqa: C901
     eventname, outcome, q = args
-    if eventname in ('pass', 'offside pass'):
+    fairplay = 238 in q
+    if fairplay:
+        a = 'non_action'
+    elif eventname in ('pass', 'offside pass'):
         cross = 2 in q
         freekick = 5 in q
         corner = 6 in q

--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -147,6 +147,10 @@ def _parse_pass_event(extra: Dict[str, Any]) -> Tuple[str, str, str]:  # noqa: C
         r = 'fail'
     elif pass_outcome == 'Pass Offside':
         r = 'offside'
+    elif pass_outcome in ['Injury Clearance', 'Unknown']:
+        # discard passes that are not part of the play
+        a = 'non_action'
+        r = 'success'
     else:
         r = 'success'
 

--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -616,7 +616,9 @@ def determine_type_id(event: pd.DataFrame) -> int:  # noqa: C901
     int
         id of the action type
     """
-    if event["own_goal"]:
+    if event["fairplay"]:
+        action_type = "non_action"
+    elif event["own_goal"]:
         action_type = "bad_touch"
     elif event["type_id"] == 8:
         if event["subtype_id"] == 80:


### PR DESCRIPTION
Fixes #262 

Passes with the following outcomes are now converted to a "non_action" in SPADL:
- Injury clearance: ball is played out of bounds to stop play for an injury (all data providers)
- Unknown: outcome is unknown (i.e., foul was called while in mid-flight) (StatsBomb only)

