### PR TITLE
Fix python version in CI setup script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
         if: steps.cache-statsbomb.outputs.cache-hit != 'true' || steps.cache-public-wyscout.outputs.cache-hit != 'true'
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         if: steps.cache-statsbomb.outputs.cache-hit != 'true' || steps.cache-public-wyscout.outputs.cache-hit != 'true'
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Upgrade pip
         if: steps.cache-statsbomb.outputs.cache-hit != 'true' || steps.cache-public-wyscout.outputs.cache-hit != 'true'


### PR DESCRIPTION
The Python version was retrieved from a non-existing variable matrix, resulting in an unpredictable Python version.