### PR TITLE
Fix SPADL conversion of Opta ball touches and recoveries

### DIFF
--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -186,7 +186,7 @@ def _fix_owngoals(actions: pd.DataFrame) -> pd.DataFrame:
     return actions
 
 
-def _fix_recoveries(df_actions: pd.DataFrame, opta_types) -> pd.DataFrame:
+def _fix_recoveries(df_actions: pd.DataFrame, opta_types: pd.Series) -> pd.DataFrame:
     """Convert ball recovery events to dribbles.
 
     This function converts the Opta 'ball recovery' event (type_id 49) into
@@ -229,7 +229,7 @@ def _fix_recoveries(df_actions: pd.DataFrame, opta_types) -> pd.DataFrame:
 
 
 def _fix_unintentional_ball_touches(
-    df_actions: pd.DataFrame, opta_type, opta_outcome
+    df_actions: pd.DataFrame, opta_type: pd.Series, opta_outcome: pd.Series
 ) -> pd.DataFrame:
     """Discard unintentional ball touches.
 


### PR DESCRIPTION
- The "ball recovery" event was previously discarded in the conversion to SPADL. It is now used to mark the start of a new dribble.
- Opta inserts a "ball touch" event after passes that are deflected and sets the end location of the deflected pass to the location where it got deflected. As a consequence, a dribble event was added between the location where the ball was deflected and the start location of the next action in the SPADL version. This commit sets the end location of the deflected pass to the start location of the next action and the outcome to "success" if the deflected pass reached a teammate.

Fixes #519