### PR TITLE
Removal of dribbles where an unsuccessful action is followed by a foul

### DIFF
--- a/socceraction/spadl/base.py
+++ b/socceraction/spadl/base.py
@@ -33,9 +33,12 @@ def _fix_actions_to_foul(actions: pd.DataFrame) -> pd.DataFrame:
     action_indices = {
         action: actions.type_id == spadlconfig.actiontypes.index(action) for action in action_list
     }
+    unsuccessful_idx = actions.result_id == 0
     combined_idx = pd.concat(action_indices.values(), axis=1).any(axis=1)
     flagged_idx = (
-        combined_idx & (next_actions.type_id == spadlconfig.actiontypes.index('foul'))
+        combined_idx
+        & (next_actions.type_id == spadlconfig.actiontypes.index('foul'))
+        & unsuccessful_idx
     ).astype(bool)
     return ~flagged_idx
 

--- a/socceraction/spadl/base.py
+++ b/socceraction/spadl/base.py
@@ -22,10 +22,21 @@ def _fix_clearances(actions: pd.DataFrame) -> pd.DataFrame:
 def _fix_actions_to_foul(actions: pd.DataFrame) -> pd.DataFrame:
     next_actions = actions.shift(-1)
     next_actions[-1:] = actions[-1:]
-    action_indices = {action: actions.type_id == spadlconfig.actiontypes.index(action) for action in
-                      ['pass', 'cross', 'corner_crossed', 'corner_short', 'freekick_crossed', 'freekick_short']}
+    action_list = [
+        'pass',
+        'cross',
+        'corner_crossed',
+        'corner_short',
+        'freekick_crossed',
+        'freekick_short',
+    ]
+    action_indices = {
+        action: actions.type_id == spadlconfig.actiontypes.index(action) for action in action_list
+    }
     combined_idx = pd.concat(action_indices.values(), axis=1).any(axis=1)
-    flagged_idx = (combined_idx & (next_actions.type_id == spadlconfig.actiontypes.index('foul'))).astype(bool)
+    flagged_idx = (
+        combined_idx & (next_actions.type_id == spadlconfig.actiontypes.index('foul'))
+    ).astype(bool)
     return ~flagged_idx
 
 

--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -252,7 +252,7 @@ def _fix_unintentional_ball_touches(
         Opta event dataframe without any unintentional ball touches.
     """
     df_actions_next = df_actions.shift(-2)
-    selector_deflected = (opta_type.shift(-1) == 'ball touch') & (opta_outcome.shift(-1) is True)
+    selector_deflected = (opta_type.shift(-1) == 'ball touch') & (opta_outcome.shift(-1))
     selector_same_team = df_actions["team_id"] == df_actions_next["team_id"]
     df_actions.loc[selector_deflected, ['end_x', 'end_y']] = df_actions_next.loc[
         selector_deflected, ['start_x', 'start_y']

--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -7,6 +7,7 @@ from pandera.typing import DataFrame
 from . import config as spadlconfig
 from .base import (
     _add_dribbles,
+    _fix_actions_to_foul,
     _fix_clearances,
     _fix_direction_of_play,
     min_dribble_length,
@@ -69,6 +70,7 @@ def convert_to_actions(events: pd.DataFrame, home_team_id: int) -> DataFrame[SPA
     actions = _fix_owngoals(actions)
     actions = _fix_direction_of_play(actions, home_team_id)
     actions = _fix_clearances(actions)
+    actions = _fix_actions_to_foul(actions)
     actions['action_id'] = range(len(actions))
     actions = _add_dribbles(actions)
 


### PR DESCRIPTION
Created to get rid of more edge cases for incorrect dribbles. In particular, I noticed dribbles added at the end of actions (mainly passes) that were followed by a foul. Incorrect dribbles were added here between the end location of the action (e.g. pass) and the foul location.

EDIT: Change made to only remove dribbles for unsuccessful actions prior to a foul.