### PR TITLE
High fidelity StatsBomb timestamps

### DIFF
--- a/socceraction/data/statsbomb/loader.py
+++ b/socceraction/data/statsbomb/loader.py
@@ -329,7 +329,7 @@ class StatsBombLoader(EventDataLoader):
 
         eventsdf = pd.DataFrame(_flatten_id(e) for e in obj)
         eventsdf["match_id"] = game_id
-        eventsdf["timestamp"] = pd.to_datetime(eventsdf["timestamp"], format="%H:%M:%S.%f")
+        eventsdf["timestamp"] = pd.to_timedelta(eventsdf["timestamp"])
         eventsdf["related_events"] = eventsdf["related_events"].apply(
             lambda d: d if isinstance(d, list) else []
         )

--- a/socceraction/data/statsbomb/schema.py
+++ b/socceraction/data/statsbomb/schema.py
@@ -2,7 +2,7 @@
 from typing import Optional
 
 import pandera as pa
-from pandera.typing import DateTime, Object, Series
+from pandera.typing import Object, Series, Timedelta
 
 from socceraction.data.schema import (
     CompetitionSchema,
@@ -57,7 +57,7 @@ class StatsBombEventSchema(EventSchema):
 
     index: Series[int]
     """Sequence notation for the ordering of events within each match."""
-    timestamp: Series[DateTime]
+    timestamp: Series[Timedelta]
     """Time in the match the event takes place, recorded to the millisecond."""
     minute: Series[int]
     """The minutes on the clock at the time of this event."""

--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -75,7 +75,6 @@ def convert_to_actions(
     actions['game_id'] = events.game_id
     actions['original_event_id'] = events.event_id
     actions['period_id'] = events.period_id
-
     actions['time_seconds'] = pd.to_timedelta(events.timestamp).dt.total_seconds()
     actions['team_id'] = events.team_id
     actions['player_id'] = events.player_id

--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -76,14 +76,7 @@ def convert_to_actions(
     actions['original_event_id'] = events.event_id
     actions['period_id'] = events.period_id
 
-    actions['time_seconds'] = (
-        60 * events.minute
-        + events.second
-        - ((events.period_id > 1) * 45 * 60)
-        - ((events.period_id > 2) * 45 * 60)
-        - ((events.period_id > 3) * 15 * 60)
-        - ((events.period_id > 4) * 15 * 60)
-    )
+    actions['time_seconds'] = pd.to_timedelta(events.timestamp).dt.total_seconds()
     actions['team_id'] = events.team_id
     actions['player_id'] = events.player_id
 

--- a/tests/spadl/test_statsbomb.py
+++ b/tests/spadl/test_statsbomb.py
@@ -49,18 +49,20 @@ class TestSpadlConvertor:
         assert action['start_y'] == spadl.field_width - ((73.6 - 0.05) / 80) * spadl.field_width
 
     @pytest.mark.parametrize(
-        'period,timestamp,minute,second',
+        'period,timestamp,minute,second,spadl_time',
         [
-            (1, '00:00:00.920', 0, 0),  # FH
-            (1, '00:47:09.453', 47, 9),  # FH extra time
-            (2, '00:19:51.740', 64, 51),  # SH (starts again at 45 min)
-            (2, '00:48:10.733', 93, 10),  # SH extra time
-            (3, '00:10:12.188', 100, 12),  # FH of extensions
-            (4, '00:13:31.190', 118, 31),  # SH of extensions
-            (5, '00:02:37.133', 122, 37),  # Penalties
+            (1, '00:00:00.920', 0, 0, 0 * 60 + 0.920),  # FH
+            (1, '00:47:09.453', 47, 9, 47 * 60 + 9.453),  # FH extra time
+            (2, '00:19:51.740', 64, 51, 19 * 60 + 51.740),  # SH (starts again at 45 min)
+            (2, '00:48:10.733', 93, 10, 48 * 60 + 10.733),  # SH extra time
+            (3, '00:10:12.188', 100, 12, 10 * 60 + 12.188),  # FH of extensions
+            (4, '00:13:31.190', 118, 31, 13 * 60 + 31.190),  # SH of extensions
+            (5, '00:02:37.133', 122, 37, 2 * 60 + 37.133),  # Penalties
         ],
     )
-    def test_convert_time(self, period: int, timestamp: str, minute: int, second: int) -> None:
+    def test_convert_time(
+        self, period: int, timestamp: str, minute: int, second: int, spadl_time: float
+    ) -> None:
         event = self.events_japbel[
             self.events_japbel.event_id == '5171bb39-0c6c-4a3d-ae1c-756011dc219f'
         ].copy()
@@ -70,15 +72,7 @@ class TestSpadlConvertor:
         event['second'] = second
         action = sb.convert_to_actions(event, self.id_bel).iloc[0]
         assert action['period_id'] == period
-        assert (
-            action['time_seconds']
-            == 60 * minute
-            - ((period > 1) * 45 * 60)
-            - ((period > 2) * 45 * 60)
-            - ((period > 3) * 15 * 60)
-            - ((period > 4) * 15 * 60)
-            + second
-        )
+        assert action['time_seconds'] == spadl_time
 
     def test_convert_pass(self) -> None:
         pass_event = self.events_japbel[


### PR DESCRIPTION
The SPADL "time_seconds" field is now derived from the StatsBomb "timestamp" field instead of the "minute" and "second" field. This allows timestamps with sub-second accuracy in the SPADL format.