### PR TITLE
[StatsBomb] Fix fidelity of shot y-coordinates

### DIFF
--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -191,11 +191,19 @@ def _convert_locations(locations: pd.Series, fidelity_version: int) -> npt.NDArr
     cell_relative_center = cell_side / 2
     coordinates = np.empty((len(locations), 2), dtype=float)
     for i, loc in enumerate(locations):
-        if isinstance(loc, list):
+        if isinstance(loc, list) and len(loc) == 2:
             coordinates[i, 0] = (loc[0] - cell_relative_center) / 120 * spadlconfig.field_length
             coordinates[i, 1] = (
                 spadlconfig.field_width
                 - (loc[1] - cell_relative_center) / 80 * spadlconfig.field_width
+            )
+        elif isinstance(loc, list) and len(loc) == 3:
+            # A coordinate in the goal frame, only used for the end location of
+            # Shot events. The y-coordinates and z-coordinates are always detailed
+            # to a tenth of a yard.
+            coordinates[i, 0] = (loc[0] - cell_relative_center) / 120 * spadlconfig.field_length
+            coordinates[i, 1] = (
+                spadlconfig.field_width - (loc[1] - 0.05) / 80 * spadlconfig.field_width
             )
     coordinates[:, 0] = np.clip(coordinates[:, 0], 0, spadlconfig.field_length)
     coordinates[:, 1] = np.clip(coordinates[:, 1], 0, spadlconfig.field_width)


### PR DESCRIPTION
The y-coordinate of a shot in the goal frame is always detailed to a tenth of a yard.