### PR TITLE
[StatsBomb] The default result of a foul should always be 'fail'

### DIFF
--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -327,7 +327,7 @@ def _parse_foul_event(extra: dict[str, Any]) -> tuple[str, str, str]:
     elif 'Red' in foul_card:
         r = 'red_card'
     else:
-        r = 'success'
+        r = 'fail'
 
     b = 'foot'
 


### PR DESCRIPTION
According to the specification of SPADL, the result of a foul should always be "fail" or a card.