### PR TITLE
[Opta] Fix bug when x or y-coordinate is zero

### DIFF
--- a/socceraction/data/opta/parsers/f24_json.py
+++ b/socceraction/data/opta/parsers/f24_json.py
@@ -92,8 +92,8 @@ class F24JSONParser(OptaJSONParser):
             }
             start_x = float(assertget(attr, 'x'))
             start_y = float(assertget(attr, 'y'))
-            end_x = _get_end_x(qualifiers) or start_x
-            end_y = _get_end_y(qualifiers) or start_y
+            end_x = _get_end_x(qualifiers)
+            end_y = _get_end_y(qualifiers)
 
             event_id = int(assertget(attr, 'id'))
             events[(game_id, event_id)] = dict(
@@ -112,8 +112,8 @@ class F24JSONParser(OptaJSONParser):
                 outcome=bool(int(attr.get('outcome', 1))),
                 start_x=start_x,
                 start_y=start_y,
-                end_x=end_x,
-                end_y=end_y,
+                end_x=end_x if end_x is not None else start_x,
+                end_y=end_y if end_y is not None else start_y,
                 qualifiers=qualifiers,
                 # Optional fields
                 assist=bool(int(attr.get('assist', 0))),

--- a/socceraction/data/opta/parsers/f24_xml.py
+++ b/socceraction/data/opta/parsers/f24_xml.py
@@ -76,8 +76,8 @@ class F24XMLParser(OptaXMLParser):
             }
             start_x = float(assertget(attr, 'x'))
             start_y = float(assertget(attr, 'y'))
-            end_x = _get_end_x(qualifiers) or start_x
-            end_y = _get_end_y(qualifiers) or start_y
+            end_x = _get_end_x(qualifiers)
+            end_y = _get_end_y(qualifiers)
 
             events[(game_id, event_id)] = dict(
                 # Fields required by the base schema
@@ -95,8 +95,8 @@ class F24XMLParser(OptaXMLParser):
                 outcome=bool(int(attr["outcome"])) if "outcome" in attr else None,
                 start_x=start_x,
                 start_y=start_y,
-                end_x=end_x,
-                end_y=end_y,
+                end_x=end_x if end_x is not None else start_x,
+                end_y=end_y if end_y is not None else start_y,
                 qualifiers=qualifiers,
                 # Optional fields
                 assist=bool(int(attr.get('assist', 0))),

--- a/socceraction/data/opta/parsers/ma3_json.py
+++ b/socceraction/data/opta/parsers/ma3_json.py
@@ -260,8 +260,8 @@ class MA3JSONParser(OptaJSONParser):
             }
             start_x = float(assertget(element, "x"))
             start_y = float(assertget(element, "y"))
-            end_x = _get_end_x(qualifiers) or start_x
-            end_y = _get_end_y(qualifiers) or start_y
+            end_x = _get_end_x(qualifiers)
+            end_y = _get_end_y(qualifiers)
 
             event_id = int(assertget(element, "id"))
             event = dict(
@@ -279,8 +279,8 @@ class MA3JSONParser(OptaJSONParser):
                 outcome=bool(int(element.get("outcome", 1))),
                 start_x=start_x,
                 start_y=start_y,
-                end_x=end_x,
-                end_y=end_y,
+                end_x=end_x if end_x is not None else start_x,
+                end_y=end_y if end_y is not None else start_y,
                 qualifiers=qualifiers,
                 # Optional fields
                 assist=bool(int(element.get("assist", 0))),

--- a/socceraction/data/opta/parsers/whoscored.py
+++ b/socceraction/data/opta/parsers/whoscored.py
@@ -208,8 +208,8 @@ class WhoScoredParser(OptaParser):
             qualifiers = {
                 int(q["type"]["value"]): q.get("value", True) for q in attr.get("qualifiers", [])
             }
-            end_x = attr.get("endX") or _get_end_x(qualifiers) or start_x
-            end_y = attr.get("endY") or _get_end_y(qualifiers) or start_y
+            end_x = attr.get("endX", _get_end_x(qualifiers))
+            end_y = attr.get("endY", _get_end_y(qualifiers))
             events[(self.game_id, event_id)] = dict(
                 # Fields required by the base schema
                 game_id=self.game_id,
@@ -229,8 +229,8 @@ class WhoScoredParser(OptaParser):
                 outcome=bool(attr["outcomeType"].get("value")) if "outcomeType" in attr else None,
                 start_x=start_x,
                 start_y=start_y,
-                end_x=end_x,
-                end_y=end_y,
+                end_x=end_x if end_x is not None else start_x,
+                end_y=end_y if end_y is not None else start_y,
                 qualifiers=qualifiers,
                 # Optional fields
                 related_player_id=int(attr.get("relatedPlayerId"))


### PR DESCRIPTION
When an event had start- or end-coordinates equal to zero, these were incorrectly handled as missing coordinates.