### PR TITLE
Use stable sort for ordering events/actions

### DIFF
--- a/socceraction/data/opta/loader.py
+++ b/socceraction/data/opta/loader.py
@@ -442,13 +442,17 @@ class OptaLoader(EventDataLoader):
         events = (
             pd.DataFrame(list(data.values()))
             .merge(_eventtypesdf, on="type_id", how="left")
-            .sort_values(["game_id", "period_id", "minute", "second", "timestamp"])
+            .sort_values(
+                ["game_id", "period_id", "minute", "second", "timestamp"], kind="mergesort"
+            )
             .reset_index(drop=True)
         )
 
         # sometimes pre-match events has -3, -2 and -1 seconds
         events.loc[events.second < 0, "second"] = 0
-        events = events.sort_values(["game_id", "period_id", "minute", "second", "timestamp"])
+        events = events.sort_values(
+            ["game_id", "period_id", "minute", "second", "timestamp"], kind="mergesort"
+        )
 
         # deleted events has wrong datetime which occurs OutOfBoundsDatetime error
         events = events[events.type_id != 43]

--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -63,7 +63,7 @@ def convert_to_actions(events: pd.DataFrame, home_team_id: int) -> DataFrame[SPA
     actions = _fix_unintentional_ball_touches(actions, events.type_name, events.outcome)
     actions = (
         actions[actions.type_id != spadlconfig.actiontypes.index('non_action')]
-        .sort_values(['game_id', 'period_id', 'time_seconds'])
+        .sort_values(['game_id', 'period_id', 'time_seconds'], kind='mergesort')
         .reset_index(drop=True)
     )
     actions = _fix_owngoals(actions)

--- a/socceraction/spadl/statsbomb.py
+++ b/socceraction/spadl/statsbomb.py
@@ -106,7 +106,7 @@ def convert_to_actions(
 
     actions = (
         actions[actions.type_id != spadlconfig.actiontypes.index('non_action')]
-        .sort_values(['game_id', 'period_id', 'time_seconds'])
+        .sort_values(['game_id', 'period_id', 'time_seconds'], kind='mergesort')
         .reset_index(drop=True)
     )
     actions = _fix_direction_of_play(actions, home_team_id)
@@ -151,7 +151,7 @@ def _insert_interception_passes(df_events: pd.DataFrame) -> pd.DataFrame:
         ] * len(df_events_interceptions)
 
         df_events = pd.concat([df_events_interceptions, df_events], ignore_index=True)
-        df_events = df_events.sort_values(["timestamp"])
+        df_events = df_events.sort_values(["timestamp"], kind="mergesort")
         df_events = df_events.reset_index(drop=True)
 
     return df_events

--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -402,7 +402,7 @@ def insert_interception_passes(df_events: pd.DataFrame) -> pd.DataFrame:
         ]
 
         df_events = pd.concat([df_events_interceptions, df_events], ignore_index=True)
-        df_events = df_events.sort_values(["period_id", "milliseconds"])
+        df_events = df_events.sort_values(["period_id", "milliseconds"], kind="mergesort")
         df_events = df_events.reset_index(drop=True)
 
     return df_events


### PR DESCRIPTION
When two events or actions have identical timestamps, we should keep the order in the original data. However, since the default sorting algorithm used by Panda's sort_values-method is not stable, the order of such events or actions could get switched.