### PR TITLE
[Wyscout] Insert interceptions before clearances and accelerations

### DIFF
--- a/socceraction/spadl/wyscout.py
+++ b/socceraction/spadl/wyscout.py
@@ -196,7 +196,7 @@ def fix_wyscout_events(df_events: pd.DataFrame) -> pd.DataFrame:
     """
     df_events = create_shot_coordinates(df_events)
     df_events = convert_duels(df_events)
-    df_events = insert_interception_passes(df_events)
+    df_events = insert_interceptions(df_events)
     df_events = add_offside_variable(df_events)
     df_events = convert_touches(df_events)
     df_events = convert_simulations(df_events)
@@ -370,12 +370,13 @@ def convert_duels(df_events: pd.DataFrame) -> pd.DataFrame:
     return df_events
 
 
-def insert_interception_passes(df_events: pd.DataFrame) -> pd.DataFrame:
-    """Insert interception actions before passes.
+def insert_interceptions(df_events: pd.DataFrame) -> pd.DataFrame:
+    """Insert interception actions before passes, clearances and dribbles.
 
-    This function converts passes (type_id 8) that are also interceptions
-    (tag interception) in the Wyscout event data into two separate events,
-    first an interception and then a pass.
+    This function converts passes (type_id 8), clearances (subtype_id 71) and
+    accelerations (subtype_id 70) that are also interceptions (tag
+    interception) in the Wyscout event data into two separate events, first an
+    interception and then a pass/clearance/dribble.
 
     Parameters
     ----------
@@ -389,7 +390,12 @@ def insert_interception_passes(df_events: pd.DataFrame) -> pd.DataFrame:
         interceptions in the Wyscout notation are transformed into two events
     """
     df_events_interceptions = df_events[
-        df_events["interception"] & (df_events["type_id"] == 8)
+        df_events["interception"]
+        & (
+            (df_events["type_id"] == 8)
+            | (df_events["subtype_id"] == 70)
+            | (df_events["subtype_id"] == 71)
+        )
     ].copy()
 
     if not df_events_interceptions.empty:

--- a/tests/spadl/test_wyscout.py
+++ b/tests/spadl/test_wyscout.py
@@ -53,10 +53,12 @@ class TestSpadlConvertor:
         events_morira = self.WSL.events(2057961)
         own_goal_event = events_morira[events_morira.event_id == 258696133]
         own_goal_actions = wy.convert_to_actions(own_goal_event, 16216)
-        assert len(own_goal_actions) == 1
-        assert own_goal_actions.iloc[0]['type_id'] == spadl.actiontypes.index('bad_touch')
-        assert own_goal_actions.iloc[0]['result_id'] == spadl.results.index('owngoal')
-        assert own_goal_actions.iloc[0]['bodypart_id'] == spadl.bodyparts.index('foot')
+        assert len(own_goal_actions) == 2  # interception + clearance
+        assert own_goal_actions.iloc[0]['type_id'] == spadl.actiontypes.index('interception')
+        assert own_goal_actions.iloc[0]['result_id'] == spadl.results.index('success')
+        assert own_goal_actions.iloc[1]['type_id'] == spadl.actiontypes.index('bad_touch')
+        assert own_goal_actions.iloc[1]['result_id'] == spadl.results.index('owngoal')
+        assert own_goal_actions.iloc[1]['bodypart_id'] == spadl.bodyparts.index('foot')
 
     def test_convert_own_goal_touches(self) -> None:
         """Tests conversion of own goals following a bad touch.


### PR DESCRIPTION
When a clearance or acceleration was tagged as an interception, no interception action was inserted before the clearance or acceleration.