### PR TITLE
[Opta] Apply _fix_unintentional_ball_touches only to passes

### DIFF
--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -281,12 +281,13 @@ def _fix_unintentional_ball_touches(
         Opta event dataframe without any unintentional ball touches.
     """
     df_actions_next = df_actions.shift(-2)
+    selector_pass = df_actions["type_id"] == spadlconfig.actiontypes.index("pass")
     selector_deflected = (opta_type.shift(-1) == "ball touch") & (opta_outcome.shift(-1))
     selector_same_team = df_actions["team_id"] == df_actions_next["team_id"]
     df_actions.loc[selector_deflected, ["end_x", "end_y"]] = df_actions_next.loc[
         selector_deflected, ["start_x", "start_y"]
     ].values
-    df_actions.loc[selector_deflected & selector_same_team, "result_id"] = (
+    df_actions.loc[selector_pass & selector_deflected & selector_same_team, "result_id"] = (
         spadlconfig.results.index("success")
     )
     return df_actions


### PR DESCRIPTION
The _fix_unintentional_ball_touches method was added to deal with "unintentional ball touch" events (`type_id=61 + outcome=0`). These are typically deflections. It sets the result of an action to "success" if the team manages to keep possession.

But this should only be applied to passes (i.e., actions for which the result depends on keeping possession). For example, the result of a shot should depend on whether a goal was scored.

Fixes #725