### PR TITLE
[Opta] Support feeds with accented characters

### DIFF
--- a/socceraction/data/opta/loader.py
+++ b/socceraction/data/opta/loader.py
@@ -193,9 +193,9 @@ def _extract_ids_from_path(path: str, pattern: str) -> dict[str, Union[str, int]
     regex = re.compile(
         ".+?"
         + re.escape(pattern)
-        .replace(r"\{competition_id\}", r"(?P<competition_id>[a-zA-Z0-9-_ ]+)")
-        .replace(r"\{season_id\}", r"(?P<season_id>[a-zA-Z0-9-_ ]+)")
-        .replace(r"\{game_id\}", r"(?P<game_id>[a-zA-Z0-9-_ ]+)")
+        .replace(r"\{competition_id\}", r"(?P<competition_id>[a-zA-Zà-üÀ-Ü0-9-_ ]+)")
+        .replace(r"\{season_id\}", r"(?P<season_id>[a-zA-Zà-üÀ-Ü0-9-_ ]+)")
+        .replace(r"\{game_id\}", r"(?P<game_id>[a-zA-Zà-üÀ-Ü0-9-_ ]+)")
     )
     m = re.match(regex, path)
     if m is None:

--- a/tests/data/test_load_opta.py
+++ b/tests/data/test_load_opta.py
@@ -31,8 +31,8 @@ def test_create_opta_json_loader(tmpdir: local) -> None:
 def test_create_opta_xml_loader(tmpdir: local) -> None:
     """It should be able to parse F7 and F24 XML feeds."""
     feeds = {
-        "f7": "f7-{competition_id}-{season_id}-{game_id}.json",
-        "f24": "f24-{competition_id}-{season_id}-{game_id}.json",
+        "f7": "f7-{competition_id}-{season_id}-{game_id}.xml",
+        "f24": "f24-{competition_id}-{season_id}-{game_id}.xml",
     }
     loader = opta.OptaLoader(root=str(tmpdir), parser="xml", feeds=feeds)
     assert loader.parsers == {
@@ -146,6 +146,36 @@ def test_deepupdate() -> None:
     t4 = {"name": "ferry", "hobby": "programming"}
     opta.loader._deepupdate(t4, {"hobby": "gaming"})
     assert t4 == {"name": "ferry", "hobby": "gaming"}
+
+
+def test_extract_ids_from_path() -> None:
+    feeds = {
+        "f1": "f1-{competition_id}-{season_id}.json",
+        "f9": "f9-{competition_id}-{season_id}-{game_id}.json",
+        "f24": "f24-{competition_id}-{season_id}-{game_id}.json",
+    }
+    assert opta.loader._extract_ids_from_path("./f24-23-2018-1.json", feeds["f24"]) == {
+        "competition_id": 23,
+        "season_id": 2018,
+        "game_id": 1,
+    }
+    with pytest.raises(
+        ValueError,
+        match=f"The filepath ./f24-23-2018.json does not match the format {feeds['f24']}.",
+    ):
+        opta.loader._extract_ids_from_path("./f24-23-2018.json", feeds["f24"])
+    with pytest.raises(
+        ValueError,
+        match=f"The filepath ./f24-23-2018_1.json does not match the format {feeds['f24']}.",
+    ):
+        opta.loader._extract_ids_from_path("./f24-23-2018_1.json", feeds["f24"])
+    assert opta.loader._extract_ids_from_path(
+        "./f24-Brasileirão-2324-1716682.json", feeds["f24"]
+    ) == {
+        "competition_id": "Brasileirão",
+        "season_id": 2324,
+        "game_id": 1716682,
+    }
 
 
 class TestJSONOptaLoader:


### PR DESCRIPTION
Adds support for loading Opta data from a file path that contains accented characters.

Fixes #730