### PR TITLE
[VAEP] Support extra time in "time" feature

### DIFF
--- a/socceraction/vaep/features.py
+++ b/socceraction/vaep/features.py
@@ -445,8 +445,11 @@ def time(actions: Actions) -> Features:
         The 'period_id', 'time_seconds' and 'time_seconds_overall' when each
         action was performed.
     """
+    match_time_at_period_start = {1: 0, 2: 45, 3: 90, 4: 105, 5: 120}
     timedf = actions[["period_id", "time_seconds"]].copy()
-    timedf["time_seconds_overall"] = ((timedf.period_id - 1) * 45 * 60) + timedf.time_seconds
+    timedf["time_seconds_overall"] = (
+        timedf.period_id.map(match_time_at_period_start) * 60
+    ) + timedf.time_seconds
     return timedf
 
 

--- a/tests/vaep/test_features.py
+++ b/tests/vaep/test_features.py
@@ -91,6 +91,18 @@ def test_bodypart_onehot(spadl_actions: DataFrame[SPADLSchema]) -> None:
     assert out.shape == (len(spadl_actions), 4 * 3)
 
 
+def test_time(spadl_actions: DataFrame[SPADLSchema]) -> None:
+    gamestates = fs.gamestates(spadl_actions)
+    out = fs.time(gamestates)
+    assert out.shape == (len(spadl_actions), 9)
+    assert out.loc[0, "period_id_a0"] == 1
+    assert out.loc[0, "time_seconds_a0"] == 0.533
+    assert out.loc[0, "time_seconds_overall_a0"] == 0.533
+    assert out.loc[200, "period_id_a0"] == 2
+    assert out.loc[200, "time_seconds_a0"] == 0.671
+    assert out.loc[200, "time_seconds_overall_a0"] == 0.671 + 45 * 60
+
+
 def test_player_possession_time(spadl_actions: DataFrame[SPADLSchema]) -> None:
     gamestates = fs.gamestates(spadl_actions)
     out = fs.player_possession_time(gamestates)


### PR DESCRIPTION
The "time_seconds_overall" feature that is generated by the "time" function now handles extra time correctly.

Fixes #670