### PR TITLE
[Atomic-VAEP] use iloc to select last value in the dataframe

### DIFF
--- a/socceraction/atomic/vaep/labels.py
+++ b/socceraction/atomic/vaep/labels.py
@@ -34,7 +34,7 @@ def scores(actions: DataFrame[AtomicSPADLSchema], nr_actions: int = 10) -> pd.Da
     for i in range(1, nr_actions):
         for c in ["team_id", "goal", "owngoal"]:
             shifted = y[c].shift(-i)
-            shifted[-i:] = y[c][len(y) - 1]
+            shifted[-i:] = y[c].iloc[len(y) - 1]
             y["%s+%d" % (c, i)] = shifted
 
     res = y["goal"]
@@ -73,7 +73,7 @@ def concedes(actions: DataFrame[AtomicSPADLSchema], nr_actions: int = 10) -> pd.
     for i in range(1, nr_actions):
         for c in ["team_id", "goal", "owngoal"]:
             shifted = y[c].shift(-i)
-            shifted[-i:] = y[c][len(y) - 1]
+            shifted[-i:] = y[c].iloc[len(y) - 1]
             y["%s+%d" % (c, i)] = shifted
 
     res = y["owngoal"]

--- a/tests/atomic/test_atomic_labels.py
+++ b/tests/atomic/test_atomic_labels.py
@@ -1,0 +1,18 @@
+import socceraction.atomic.spadl.utils as spu
+import socceraction.atomic.vaep.labels as lab
+from pandera.typing import DataFrame
+from socceraction.atomic.spadl import AtomicSPADLSchema
+
+
+def test_scores(atomic_spadl_actions: DataFrame[AtomicSPADLSchema]) -> None:
+    nr_actions = 10
+    atomic_spadl_actions = spu.add_names(atomic_spadl_actions)
+    scores = lab.scores(atomic_spadl_actions, nr_actions)
+    assert len(scores) == len(atomic_spadl_actions)
+
+
+def test_conceds(atomic_spadl_actions: DataFrame[AtomicSPADLSchema]) -> None:
+    nr_actions = 10
+    atomic_spadl_actions = spu.add_names(atomic_spadl_actions)
+    concedes = lab.concedes(atomic_spadl_actions, nr_actions)
+    assert len(concedes) == len(atomic_spadl_actions)


### PR DESCRIPTION
This commit fixes a bug in the scores and concedes functions in atomic vaep, where the intention is to grab the last element in the dataframe and assign that value to the end of the shifted dataframe.

See also #718
Fixes #749