### PR TITLE
Differentiate between keeper and fieldplayer save event in opta-spadl.

### DIFF
--- a/socceraction/spadl/opta.py
+++ b/socceraction/spadl/opta.py
@@ -166,7 +166,10 @@ def _get_type_id(args: tuple[str, bool, dict[int, Any]]) -> int:  # noqa: C901
         else:
             a = "shot"
     elif eventname == "save":
-        a = "keeper_save"
+        if 94 in q:
+            a = "non_action"
+        else:
+            a = "keeper_save"
     elif eventname == "claim":
         a = "keeper_claim"
     elif eventname == "punch":


### PR DESCRIPTION
close #850 

I could not get the tests to work locally, partly because I am running on MacOs:

For instance in:
```python
def test_universal_feeds(tmpdir: local) -> None:
    """It should replace forward slashes in glob patterns on Windows."""
    feeds = {
        "myfeed": "{competition_id}/{season_id}/{game_id}.json",
    }
    parser = {
        "myfeed": opta.parsers.base.OptaParser,
    }
    loader = opta.OptaLoader(root=str(tmpdir), parser=parser, feeds=feeds)

    if "win" in sys.platform:
        assert loader.feeds["myfeed"] == "{competition_id}\\{season_id}\\{game_id}.json"

    elif "linux" in sys.platform:
        assert loader.feeds["myfeed"] == "{competition_id}/{season_id}/{game_id}.json"
```

`sys.platform` returns `"darwin"` for MacOs, which results in the test assuming that this is a Windows based system and thus this test fails locally for me. 

I changed almost nothing, so I am not assuming I broke any tests, but again, could not really check it locally.

I checked with my local files and the example ran in #850 works as expected with the proposed change.