### PR TITLE
Fix missing coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         with:
           name: coverage-data-${{ matrix.os }}-${{ matrix.python-version }}
           path: ".coverage.*"
+          include-hidden-files: true
       - name: Upload documentation
         if: matrix.session == 'docs-build'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
From September 2nd, 2024, the GitHub action update-artifact does not upload hidden files and folders by default. This caused trouble with .coverage files.